### PR TITLE
Added support for ECDSA signatures

### DIFF
--- a/src/core/iTextSharp/text/pdf/PdfPKCS7.cs
+++ b/src/core/iTextSharp/text/pdf/PdfPKCS7.cs
@@ -170,6 +170,7 @@ namespace iTextSharp.text.pdf {
             algorithmNames["1.3.36.3.3.1.3"] = "RSA";
             algorithmNames["1.3.36.3.3.1.2"] = "RSA";
             algorithmNames["1.3.36.3.3.1.4"] = "RSA";
+            algorithmNames["1.3.14.3.2.29"] = "RSA";
 
             algorithmNames["1.2.840.10045.4.1"] = "ECDSA";
             algorithmNames["1.2.840.10045.4.3.2"] = "ECDSA";

--- a/src/core/iTextSharp/text/pdf/PdfPKCS7.cs
+++ b/src/core/iTextSharp/text/pdf/PdfPKCS7.cs
@@ -170,7 +170,12 @@ namespace iTextSharp.text.pdf {
             algorithmNames["1.3.36.3.3.1.3"] = "RSA";
             algorithmNames["1.3.36.3.3.1.2"] = "RSA";
             algorithmNames["1.3.36.3.3.1.4"] = "RSA";
-            
+
+            algorithmNames["1.2.840.10045.4.1"] = "ECDSA";
+            algorithmNames["1.2.840.10045.4.3.2"] = "ECDSA";
+            algorithmNames["1.2.840.10045.4.3.3"] = "ECDSA";
+            algorithmNames["1.2.840.10045.4.3.4"] = "ECDSA";
+
             allowedDigests["MD5"] = "1.2.840.113549.2.5";
             allowedDigests["MD2"] = "1.2.840.113549.2.2";
             allowedDigests["SHA1"] = "1.3.14.3.2.26";


### PR DESCRIPTION
Added naming decoded support for ECDSA to itextsharp.
BouncyCastle support the algorithm out of the box but itext did not have the required OID's in the lookup table.
